### PR TITLE
Adding a section to the readme on `bump_version` script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # homebrew-tap
 A collection of @Homebrew formula for @roboto-ai
+
+## Running the version bump script
+```bash
+./bump_version.sh 0.0.1
+```
+You specify the version as an argument to the script without the `v` prefix.
+
+This script depends on `sha256sum` being available. On macOS, you can install it using `brew install coreutils`.

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,7 +1,13 @@
 #/bin/env bash
 set -eufo pipefail
 
-# A script to update the version and shas
+"""
+ A script to update the version and shas
+
+ Usage: ./bump_version.sh <version>
+ Example: ./bump_version.sh 0.0.1
+"""
+
 version=${1/v/}
 cli_cask="Casks/roboto.rb"
 agent_cask="Casks/roboto-agent.rb"

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,12 +1,12 @@
 #/bin/env bash
 set -eufo pipefail
 
-"""
+<<description
  A script to update the version and shas
 
  Usage: ./bump_version.sh <version>
  Example: ./bump_version.sh 0.0.1
-"""
+description
 
 version=${1/v/}
 cli_cask="Casks/roboto.rb"


### PR DESCRIPTION
Adding a section to the readme on `bump_version` script usage and a section on if `sha256sum` isn't available, how to install it on MacOS. 